### PR TITLE
[  CommunityForm ] 댓글 컴포넌트 GUI 대로 수정

### DIFF
--- a/components/community/Reply.tsx
+++ b/components/community/Reply.tsx
@@ -11,7 +11,7 @@ export default function Reply() {
   };
 
   const handleInputColor = () => {
-    replyText.length === 0 ? setInputColor(false) : setInputColor(true);
+    setInputColor(replyText.length !== 0);
   };
 
   return (
@@ -102,11 +102,6 @@ const StInputContent = styled.div<{ inputColor: boolean }>`
     width: 67.6rem;
     height: 4.2rem;
 
-    font-style: normal;
-    font-weight: 400;
-    font-size: 21.3762px;
-    line-height: 31px;
-
     color: ${({ theme }) => theme.colors.black};
 
     ${({ theme }) => theme.fonts.b4_15_regular_146};
@@ -131,12 +126,10 @@ const StInputBtn = styled.span<{ inputColor: boolean }>`
   width: 7.6rem;
   height: 4.2rem;
 
-  color: ${({ theme, inputColor }) =>
-    !inputColor ? theme.colors.gray006 : theme.colors.white};
-
   background-color: ${({ theme, inputColor }) =>
     !inputColor ? theme.colors.gray003 : theme.colors.mainDarkgreen};
-
+  color: ${({ theme, inputColor }) =>
+    !inputColor ? theme.colors.gray006 : theme.colors.white};
   ${({ theme }) => theme.fonts.b2_18_medium_130};
 
   border-radius: 0.5rem;

--- a/components/community/Reply.tsx
+++ b/components/community/Reply.tsx
@@ -29,7 +29,7 @@ export default function Reply() {
             onChange={handleInputText}
           />
         </StInputContent>
-        <StInputBtn inputColor={inputColor}>등록</StInputBtn>
+        <StInputBtn inputColor={inputColor}>입력</StInputBtn>
       </StInputForm>
       <ReplyContent
         userNickname="희지맘"

--- a/components/community/Reply.tsx
+++ b/components/community/Reply.tsx
@@ -1,18 +1,35 @@
 import styled from '@emotion/styled';
-import ReplyContent from './ReplyContent';
+import ReplyContent from '../community/ReplyContent';
+import { useState } from 'react';
 
 export default function Reply() {
+  const [inputColor, setInputColor] = useState<boolean>(false);
+  const [replyText, setReplyText] = useState<string>('');
+
+  const handleInputText = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setReplyText(e.target.value);
+  };
+
+  const handleInputColor = () => {
+    replyText.length === 0 ? setInputColor(false) : setInputColor(true);
+  };
+
   return (
     <StReplyWrapper>
       <StReplyTitle>
-        <p>댓글</p>
+        <h1>댓글</h1>
+        <p>23</p>
       </StReplyTitle>
       <StInputForm>
-        <StInputContent>
-          <p>예현맘</p>
-          <input type="text" placeholder="댓글을 남겨보세요" />
+        <StInputContent inputColor={inputColor}>
+          <input
+            type="text"
+            placeholder="댓글을 남겨 보세요"
+            onKeyUp={handleInputColor}
+            onChange={handleInputText}
+          />
         </StInputContent>
-        <StInputBtn>등록</StInputBtn>
+        <StInputBtn inputColor={inputColor}>등록</StInputBtn>
       </StInputForm>
       <ReplyContent
         userNickname="희지맘"
@@ -41,20 +58,26 @@ export default function Reply() {
 const StReplyWrapper = styled.section`
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  justify-content: flex-start;
 `;
-const StReplyTitle = styled.h1`
+const StReplyTitle = styled.article`
   display: flex;
   flex-direction: row;
   align-items: flex-start;
 
-  margin-bottom: 2.87rem;
+  margin-bottom: 2.3rem;
 
-  font-style: normal;
-  font-weight: 500;
-  font-size: 2.8rem;
-  line-height: 4rem;
+  ${({ theme }) => theme.fonts.t3_19_medium_130}
+
+  h1 {
+    margin-right: 0.4rem;
+
+    color: ${({ theme }) => theme.colors.black};
+  }
+
+  p {
+    color: ${({ theme }) => theme.colors.mainDarkgreen};
+  }
 `;
 const StInputForm = styled.article`
   display: flex;
@@ -62,53 +85,61 @@ const StInputForm = styled.article`
   justify-content: space-between;
   align-items: center;
 
-  margin-bottom: 6.9rem;
-  padding-left: 4.3rem;
-  padding-right: 3.2rem;
+  margin-bottom: 4.8rem;
 
   width: 77.6rem;
-  height: auto;
-  min-height: 13.6rem;
-
-  border: 0.1rem solid ${({ theme }) => theme.colors.gray005};
-  border-radius: 1rem;
 `;
-const StInputContent = styled.div`
+const StInputContent = styled.div<{ inputColor: boolean }>`
   display: flex;
   flex-direction: column;
-
-  p {
-    margin-bottom: 0.3rem;
-
-    font-style: normal;
-    font-weight: 500;
-    font-size: 23.2351px;
-    line-height: 34px;
-  }
+  justify-content: center;
+  align-items: center;
 
   input {
+    margin-right: 2.4rem;
+    padding-left: 1.8rem;
+
+    width: 67.6rem;
+    height: 4.2rem;
+
     font-style: normal;
     font-weight: 400;
     font-size: 21.3762px;
     line-height: 31px;
 
+    color: ${({ theme }) => theme.colors.black};
+
+    ${({ theme }) => theme.fonts.b4_15_regular_146};
+
+    border: 0.1rem solid
+      ${({ theme, inputColor }) =>
+        !inputColor ? theme.colors.gray007 : theme.colors.mainDarkgreen};
+    border-radius: 0.65rem;
+
     &::placeholder {
       font-family: Pretendard;
+
+      color: ${({ theme }) => theme.colors.gray005};
     }
   }
 `;
-const StInputBtn = styled.span`
-  padding: 0.5rem 2.8rem;
+const StInputBtn = styled.span<{ inputColor: boolean }>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
-  font-style: normal;
-  font-weight: 400;
-  font-size: 23.2351px;
-  line-height: 32px;
+  width: 7.6rem;
+  height: 4.2rem;
 
-  color: ${({ theme }) => theme.colors.mainDarkgreen};
-  background-color: ${({ theme }) => theme.colors.lightGreen};
-  border: 2px solid ${({ theme }) => theme.colors.mainDarkgreen};
-  border-radius: 1rem;
+  color: ${({ theme, inputColor }) =>
+    !inputColor ? theme.colors.gray006 : theme.colors.white};
+
+  background-color: ${({ theme, inputColor }) =>
+    !inputColor ? theme.colors.gray003 : theme.colors.mainDarkgreen};
+
+  ${({ theme }) => theme.fonts.b2_18_medium_130};
+
+  border-radius: 0.5rem;
 
   cursor: pointer;
 `;

--- a/components/community/ReplyContent.tsx
+++ b/components/community/ReplyContent.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 interface ReplyContentProps {
   userNickname?: string;
   content: string;
-  createdAt?: string;
+  createdAt: string;
 }
 
 export default function ReplyContent(props: ReplyContentProps) {

--- a/components/community/ReplyContent.tsx
+++ b/components/community/ReplyContent.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 
 interface ReplyContentProps {
-  userNickname: string;
+  userNickname?: string;
   content: string;
-  createdAt: string;
+  createdAt?: string;
 }
 
 export default function ReplyContent(props: ReplyContentProps) {
@@ -12,10 +12,10 @@ export default function ReplyContent(props: ReplyContentProps) {
     <StReplyContentWrapper>
       <StReplyInfo>
         <p>{userNickname}</p>
-        <span>{createdAt}</span>
       </StReplyInfo>
       <StReplyContents>
         <p>{content}</p>
+        <span>{createdAt} · 신고</span>
       </StReplyContents>
     </StReplyContentWrapper>
   );
@@ -23,42 +23,37 @@ export default function ReplyContent(props: ReplyContentProps) {
 
 const StReplyContentWrapper = styled.section`
   width: 77.6rem;
-  margin-bottom: 3.3rem;
-
-  border-bottom: 0.1rem solid ${({ theme }) => theme.colors.gray005};
+  margin-bottom: 4rem;
 `;
 
 const StReplyInfo = styled.div`
   display: flex;
-  flex-direction: row;
-  align-items: center;
-
-  margin-bottom: 1.1rem;
 
   p {
+    margin-bottom: 0.8rem;
     padding-right: 0.9rem;
 
-    font-style: normal;
-    font-weight: 500;
-    font-size: 23.2351px;
-    line-height: 34px;
-  }
-
-  span {
-    font-style: normal;
-    font-weight: 350;
-    font-size: 19.5174px;
-    line-height: 28px;
+    ${({ theme }) => theme.fonts.b3_16_semibold_140}
   }
 `;
 
 const StReplyContents = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+
   margin-bottom: 2.8rem;
 
   p {
-    font-style: normal;
-    font-weight: 400;
-    font-size: 21.3762px;
-    line-height: 31px;
+    margin-bottom: 0.8rem;
+
+    color: ${({ theme }) => theme.colors.black};
+    ${({ theme }) => theme.fonts.b4_15_regular_146}
+  }
+
+  span {
+    color: ${({ theme }) => theme.colors.gray007};
+
+    ${({ theme }) => theme.fonts.b6_13_regular_120}
   }
 `;

--- a/styles/emotion.d.ts
+++ b/styles/emotion.d.ts
@@ -50,6 +50,7 @@ declare module '@emotion/react' {
       b5_14_medium_140: SerializedStyles;
       b5_14_regular_140: SerializedStyles;
       b6_13_medium_120: SerializedStyles;
+      b6_13_regular_120: SerializedStyles;
       b7_12_bold_120: SerializedStyles;
       b7_12_medium_140: SerializedStyles;
       b7_12_regular_120: SerializedStyles;

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -92,6 +92,7 @@ const fonts = {
   b5_14_medium_140: FONT({ weight: 500, size: 1.4, height: 1.96, spacing: 0 }),
   b5_14_regular_140: FONT({ weight: 400, size: 1.4, height: 1.96, spacing: 0 }),
   b6_13_medium_120: FONT({ weight: 500, size: 1.3, height: 1.56, spacing: 0 }),
+  b6_13_regular_120: FONT({ weight: 400, size: 1.3, height: 1.56, spacing: 0 }),
   b7_12_bold_120: FONT({ weight: 700, size: 1.2, height: 1.44, spacing: 0 }),
   b7_12_medium_140: FONT({ weight: 500, size: 1.2, height: 1.68, spacing: 0 }),
   b7_12_regular_120: FONT({ weight: 400, size: 1.2, height: 1.44, spacing: 0 }),

--- a/types/community.ts
+++ b/types/community.ts
@@ -6,7 +6,7 @@ export interface ImgData {
 export interface ReplyData {
   userNickname?: string;
   content: string;
-  createdAt?: string;
+  createdAt: string;
 }
 // 커뮤니티 데이터
 export interface CommunityData {


### PR DESCRIPTION
## 🔥 Related Issues
- close #87 

## 🎡 작업 내용
- [x] ~ 댓글 뷰 GUI 대로 수정 작업
- [x] ~ 페이지 구조화 및 스타일링

## ✅ PR Point
- input 이 onchange 되면 border 와 등록버튼의 색상이 변경되도록 하였습니다.
- git push 자체가 안돼서 재클론 받고 코드 옮기는 작업을 진행했습니다............
- 때문에 develop 과 Reply 제외하고 코드는 동일하겠으나 혹시 이상한 점 발견하면 리뷰 부탁 드립니다.

## 👀 스크린샷 / GIF / 링크

https://user-images.githubusercontent.com/97586683/179605388-0f797be7-2ce9-47fb-af53-005bb4a3b07a.mp4


## 📚 Reference
- https://velog.io/@hyunjoong/react-button-%ED%99%9C%EC%84%B1%ED%99%94
