### PR TITLE
[ ViewProduct ] 필터 오류 수정

### DIFF
--- a/components/viewProduct/ProductFilter.tsx
+++ b/components/viewProduct/ProductFilter.tsx
@@ -70,7 +70,11 @@ export default function ProductFilter() {
             <FilterDropdown
               categoryInfo={filterListData[idx]}
               categoryIdx={idx}
-              isExcept={idx == 3 || toyKindList.length !== 0 ? true : false}
+              isExcept={
+                idx == 3 || (idx == 4 && toyKindList.length !== 0)
+                  ? true
+                  : false
+              }
               isDrop={visibility[idx]}
               checkedItem={checkedItems[idx]}
               categoryKey={title}

--- a/components/viewProduct/ProductFilter.tsx
+++ b/components/viewProduct/ProductFilter.tsx
@@ -92,6 +92,10 @@ const StFilterWrapper = styled.div`
   padding-left: 1.2rem;
   margin-right: 2.4rem;
   margin-bottom: 7.2rem;
+
+  align-self: flex-start;
+  position: sticky;
+  top: 8.2rem;
 `;
 const StFilterTitle = styled.div`
   display: flex;

--- a/pages/viewProduct.tsx
+++ b/pages/viewProduct.tsx
@@ -85,7 +85,7 @@ export default function viewProduct({
           <StFilterSectionWrapper>
             <ProductFilter />
             <StContentSection>
-              {filterTagList.length != 0 && <TagSection />}
+              {filterTagList.length !== 0 && <TagSection />}
               <StFilterBarWrapper>
                 <PriceFilter
                   priceDesc={priceDesc}
@@ -132,8 +132,7 @@ const StViewProductWrapper = styled.div`
 `;
 const StFilterSectionWrapper = styled.section`
   display: flex;
-
-  height: fit-content;
+  height: auto;
 `;
 const StFilterBarWrapper = styled.div`
   display: flex;


### PR DESCRIPTION
## 🔥 Related Issues
- close #126

## 🎡 작업 내용
- [x] ~  fit-content 되는 섹션 고치기
- [x] ~ 필터 상단 고정( 스크롤 내리면 고정

## ✅ PR Point
- 필터 섹션의 height는 기본적으로 14.8rem 고정이지만, '특성' 섹션의 경우 요소가 5개 미만이기 때문에 남는 공간이 남아 이때만 height를 지정된 padding, margin에 맞게 fit-content로 보여주기 위해 isExcept라는 props를 받아 인덱스를 확인해줬습니다. 아이콘 바 누를 때,  '장난감 종류'섹션의 요소 개수가 달라질 때마다 height를 맞추기 위해 마찬가지로 이것을 이용했는데, 섹션의 인덱스를 구분않고 바꿔 모든 섹션이 fit-content가 되는 현상을, 장난감 종류 섹션의 인덱스를 넘겨주어 해당 섹션만 fit-content가 되도록 바꿨습니다.
- position:sticky 를 이용해 스크롤 내려도 필터를 상단 고정하려고 했으나, 부모 요소가 display:flex 의 경우라 적용하지 못했습니다. 이에 align-self 속성을 활용하여 필터 컴포넌트에 적용해주고, sticky 를 사용할 수 있었습니다. 

이 속성을 이용하면 플렉스 요소마다 서로 다른 align 속성값을 설정할 수 있습니다.

## 😡 Trouble Shooting

## 👀 스크린샷 / GIF / 링크
![필터 고정](https://user-images.githubusercontent.com/80065381/180074917-d20205f9-0371-4fd7-99b6-c5a9df70fc82.gif)

## 📚 Reference
- https://velog.io/@perfumellim/TIL-display%EA%B0%80-flex%EC%9D%BC-%EB%95%8C-position-sticky%EC%A3%BC%EA%B8%B0
